### PR TITLE
Support local configuration overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ composer install
 cp config.php config.local.php # ajuste credenciais se necessário
 ```
 
-Configure as credenciais de banco em `config.php` (ou arquivo local carregado manualmente) e aponte o servidor web para o diretório `public/`.
+A aplicação carrega automaticamente `config.local.php`, quando presente, mesclando-o ao `config.php`. Ajuste suas credenciais nesse arquivo local (ou diretamente em `config.php`, se preferir) e aponte o servidor web para o diretório `public/`.
 
 ## Cron
 

--- a/cron/faturar_mensal.php
+++ b/cron/faturar_mensal.php
@@ -3,6 +3,14 @@ declare(strict_types=1);
 
 require __DIR__.'/../vendor/autoload.php';
 $config = require __DIR__.'/../config.php';
+$localConfigPath = __DIR__.'/../config.local.php';
+
+if (is_file($localConfigPath)) {
+  $localConfig = require $localConfigPath;
+  if (is_array($localConfig)) {
+    $config = array_replace_recursive($config, $localConfig);
+  }
+}
 $app = new App\Bootstrap($config);
 $invoice = new App\Models\Invoice($app);
 $competencia = (new DateTime('first day of this month'))->format('Y-m-01');

--- a/public/index.php
+++ b/public/index.php
@@ -5,6 +5,14 @@ use App\Router;
 
 require __DIR__.'/../vendor/autoload.php';
 $config = require __DIR__.'/../config.php';
+$localConfigPath = __DIR__.'/../config.local.php';
+
+if (is_file($localConfigPath)) {
+  $localConfig = require $localConfigPath;
+  if (is_array($localConfig)) {
+    $config = array_replace_recursive($config, $localConfig);
+  }
+}
 
 if (session_status() === PHP_SESSION_NONE) {
   session_start();


### PR DESCRIPTION
## Summary
- load config.local.php automatically when present for the web entrypoint and monthly billing cron
- allow overriding only the settings provided in config.php using array_replace_recursive
- document the local configuration override behaviour in the README

## Testing
- php -l public/index.php
- php -l cron/faturar_mensal.php

------
https://chatgpt.com/codex/tasks/task_e_68d0b35e62288332b4e6c2897d8f9b57